### PR TITLE
docs(documentation): update javascript sdk docs

### DIFF
--- a/src/documentation/51.javascript-sdk.md
+++ b/src/documentation/51.javascript-sdk.md
@@ -139,7 +139,7 @@ npm install @myparcel/constants
   DeliveryTypeId.Pickup // 4
   // etc
   ```
-- **Countries**
+- **Countries** Contains constants for all countries, by name
  ```js
   import { NETHERLANDS, GERMANY, EU_COUNTRIES } from '@myparcelnl/constants/countries';
 

--- a/src/documentation/51.javascript-sdk.md
+++ b/src/documentation/51.javascript-sdk.md
@@ -88,13 +88,40 @@ console.log(result); // [ 123456 ] (The ID of the shipment that was just created
 
 ### Using constants
 
-Our SDK exposes some constants to make working with our API easier.
+Install [@myparcelnl/constants] to be able to use lots of pre-defined constants needed throughout our entire ecosystem, like carrier and package type IDs, country codes and names of delivery options.
+
+Install [@myparcel/constants] with your package manager:
+
+<CodeGroup id="npm">
+  <CodeGroupItem title="yarn">
+
+```bash
+yarn add @myparcel/constants
+```
+
+  </CodeGroupItem>
+  <CodeGroupItem title="pnpm">
+
+```bash
+pnpm add @myparcel/constants
+```
+
+  </CodeGroupItem>
+  <CodeGroupItem title="npm">
+
+```bash
+npm install @myparcel/constants
+```
+
+  </CodeGroupItem>
+</CodeGroup>
 
 - **Carriers**
   ```js
-  import { CarrierName } from '@myparcelnl/constants';
+  import { CarrierId, CarrierName } from '@myparcelnl/constants';
   
   CarrierName.PostNL // "postnl"
+  CarrierId.Dhl // 6
   ```
 - **Package types**
   ```js
@@ -112,6 +139,22 @@ Our SDK exposes some constants to make working with our API easier.
   DeliveryTypeId.Pickup // 4
   // etc
   ```
+- **Countries**
+ ```js
+  import { NETHERLANDS, GERMANY, EU_COUNTRIES } from '@myparcelnl/constants/countries';
+
+  NETHERLANDS // "NL"
+  GERMANY // "DE"
+  EU_COUNTRIES // ["AT", "BE", ...]
+ ```
+- **States**
+ ```js
+  import { GEORGIA, STATES_US, STATES_CANADA } from '@myparcelnl/constants/states';
+
+  GEORGIA // "GA"
+  STATES_US // ["AL", "AK", ...]
+  STATES_CANADA // ["AB", "BC", ...]
+ ```
 
 ### Creating a new endpoint
 

--- a/src/documentation/51.javascript-sdk.md
+++ b/src/documentation/51.javascript-sdk.md
@@ -47,7 +47,7 @@ The client is Promise-based, so you can use `async/await`, or `Promise.then`.
 First, instantiate an SDK and pass the endpoints you want to use.
 
 ```js
-import { createPrivateSdk, PostShipments } from '@myparcel/sdk';
+import { createPrivateSdk, FetchClient, PostShipments } from '@myparcel/sdk';
 
 const clientConfig = {
   headers: {
@@ -71,7 +71,7 @@ const result = await sdk.postShipments({
     {
       carrier: 1,
       options: {
-        package_type: 'package',
+        package_type: 1,
       },
       recipient: {
         cc: 'NL',
@@ -90,36 +90,26 @@ console.log(result); // [ 123456 ] (The ID of the shipment that was just created
 
 Our SDK exposes some constants to make working with our API easier.
 
-- Carriers
+- **Carriers**
   ```js
-  import { CARRIERS } from '@myparcelnl/sdk';
+  import { CarrierName } from '@myparcelnl/constants';
   
-  CARRIERS.POSTNL_NAME // "postnl"
+  CarrierName.PostNL // "postnl"
   ```
-- **Package types:** Contains all package types' names and IDs.
+- **Package types**
   ```js
-  import { PACKAGE_TYPES } from '@myparcelnl/sdk';
+  import { PackageTypeId, PackageTypeName } from '@myparcelnl/constants';
   
-  PACKAGE_TYPES.DIGITAL_STAMP_NAME // "digital_stamp"
-  PACKAGE_TYPES.PACKAGE_ID // 1
-  PACKAGE_TYPES.LETTER // { ID: 3, NAME: "letter" }
+  PackageTypeName.DigitalStamp // "digital_stamp"
+  PackageTypeId.Package // 1
   // etc
   ```
 - **Delivery types**
   ```js
-  import { DELIVERY_TYPES } from '@myparcelnl/sdk';
+  import { DeliveryTypeId, DeliveryTypeName } from '@myparcelnl/constants';
 
-  DELIVERY_TYPES.STANDARD_NAME // "standard"
-  DELIVERY_TYPES.PICKUP_ID // 4
-  DELIVERY_TYPES.MORNING // { ID: 1, NAME: "morning" }
-  // etc
-  ```
-- **Countries:** Contains constants for all countries, by name.
-  ```js
-  import { COUNTRIES } from '@myparcelnl/sdk';
-  
-  COUNTRIES.NETHERLANDS // "NL"
-  COUNTRIES.GERMANY // "DE"
+  DeliveryTypeName.Standard // "standard"
+  DeliveryTypeId.Pickup // 4
   // etc
   ```
 


### PR DESCRIPTION
I noticed the JavaScript SDK docs are out of date and don't represent the current state of the SDK's API.

Note that I also removed the `COUNTRIES` section since those are not exposed in the `@myparcel/constants` package, which might be a bug.

It also does not yet reflect the need to install `@myparcel/constants` if you want to use any constants. Not sure if you want me to add that to the initial installation instructions or add it separately to the "Using constants" section?