### PR TITLE
docs: update api rate limits

### DIFF
--- a/src/api-reference/01.requests.md
+++ b/src/api-reference/01.requests.md
@@ -89,6 +89,7 @@ seconds later. Sending some POSTs to the same endpoint is allowed though, it fol
 | Method | Endpoint                                        | Rate limit                |
 |--------|-------------------------------------------------|---------------------------|
 | GET    | `/`                                             | 30 calls in 5 minutes *   |
+| GET    | `/delivery_options`                             | 300 calls in 5 minutes    |
 | GET    | `/drop_off_points`                              | 300 calls in 5 minutes *  |
 | GET    | `/fulfilment/orders`                            | 100 calls in 5 minutes *  |
 | POST   | `/fulfilment/orders`                            | 100 calls in 5 minutes *  |
@@ -96,8 +97,8 @@ seconds later. Sending some POSTs to the same endpoint is allowed though, it fol
 | GET    | `/fulfilment/orders/{identifier}`               | 100 calls in 5 minutes *  |
 | DELETE | `/fulfilment/orders/{identifier}`               | 100 calls in 5 minutes *  |
 | GET    | `/fulfilment/orders/{identifiers}/packing_slip` | 100 calls in 5 minutes *  |
-| GET    | `/pickup_locations`                             | 30 calls in 5 minutes     |
-| POST   | `/return_shipments`                             | 30 calls in 5 minutes *   |
+| GET    | `/pickup_locations`                             | 300 calls in 5 minutes    |
+| POST   | `/return_shipments`                             | 300 calls in 5 minutes *  |
 | GET    | `/shipments`                                    | 300 calls in 5 minutes *  |
 | PATCH  | `/shipments`                                    | 300 calls in 5 minutes *  |
 | POST   | `/shipments`                                    | 300 calls in 5 minutes *  |
@@ -105,7 +106,7 @@ seconds later. Sending some POSTs to the same endpoint is allowed though, it fol
 | GET    | `/shipments/{ids}`                              | 1000 calls in 5 minutes * |
 | DELETE | `/shipments/{ids}`                              | 300 calls in 5 minutes *  |
 | GET    | `/shipment_labels/{ids}`                        | 300 calls in 5 minutes *  |
-| GET    | `/tracktraces/{ids?}`                           | 100 calls in 5 minutes    |
+| GET    | `/tracktraces/{ids?}`                           | 300 calls in 5 minutes    |
 | GET    | `/webhook_subscriptions`                        | 150 calls in 5 minutes    |
 | POST   | `/webhook_subscriptions`                        | 30 calls in 5 minutes     |
 | DELETE | `/webhook_subscriptions`                        | 30 calls in 5 minutes     |

--- a/src/api-reference/08.delivery-options.md
+++ b/src/api-reference/08.delivery-options.md
@@ -2,8 +2,6 @@
 
 ## 8.A Get delivery options
 
-This endpoint has a rate limit. For more information, see <ApiLink to="1_D">rate limiting</ApiLink>.
-
 ### 8.A.1 Overview
 
 **Defaults**  
@@ -29,7 +27,6 @@ easier integration.
 | **URI** | https://api.myparcel.nl/delivery_options | |
 | ^^ | https://api.myparcel.nl/pickup_locations | |
 | Methods | GET | |
-| Rate Limit | 30 requests in 5 minutes | |
 | URI parameters | – | |
 | Query parameters | cc | [country_code] |
 | ^^ | postal_code | [string] |


### PR DESCRIPTION
Increase rate limit to 300/5min for these endpoints:
- /delivery_options
- /pickup_locations
- /return_shipments
- /tracktraces/{ids?}