### PR TITLE
docs: Make rate limit on /delivery_options and /pickup_locations more fine grained

### DIFF
--- a/src/api-reference/01.requests.md
+++ b/src/api-reference/01.requests.md
@@ -69,9 +69,9 @@ Default rate limits apply to many of our documented endpoints. Customers who wou
 Example: If you make 100 GET requests within 15 seconds to the same endpoint with an allowed rate limit of 100 request per 5 minutes, you will only be able to continue sending GETs 4 minutes 45 seconds later. Sending some POSTs to the same endpoint is allowed though, it follows its own rate limit.
 
 | Method | Endpoint                                        | Rate limit              |
-| ------ | ----------------------------------------------- | ----------------------- |
+| ------ | ----------------------------------------------- |-------------------------|
 | GET    | `/`                                             | 30 calls in 5 minutes   |
-| GET    | `/delivery_options`                             | 300 calls in 5 minutes  |
+| GET    | `/delivery_options`                             | 60 calls in 1 minute    |
 | GET    | `/drop_off_points`                              | 300 calls in 5 minutes  |
 | GET    | `/fulfilment/orders`                            | 300 calls in 5 minutes  |
 | POST   | `/fulfilment/orders`                            | 100 calls in 5 minutes  |
@@ -79,7 +79,7 @@ Example: If you make 100 GET requests within 15 seconds to the same endpoint wit
 | GET    | `/fulfilment/orders/{identifier}`               | 300 calls in 5 minutes  |
 | DELETE | `/fulfilment/orders/{identifier}`               | 300 calls in 5 minutes  |
 | GET    | `/fulfilment/orders/{identifiers}/packing_slip` | 100 calls in 5 minutes  |
-| GET    | `/pickup_locations`                             | 300 calls in 5 minutes  |
+| GET    | `/pickup_locations`                             | 60 calls in 1 minute    |
 | POST   | `/return_shipments`                             | 300 calls in 5 minutes  |
 | GET    | `/shipments`                                    | 500 calls in 5 minutes  |
 | PATCH  | `/shipments`                                    | 300 calls in 5 minutes  |


### PR DESCRIPTION
Enforce the same rate limit on endpoints /delivery_options and /pickup_locations, but in a finer grain, to lower the possibility of misuse.