### PR TITLE
docs(SB-2143): ISIC codes to HS codes (and more)

### DIFF
--- a/src/api-reference/04.data-types.md
+++ b/src/api-reference/04.data-types.md
@@ -100,14 +100,22 @@ Numeric value with decimal fractions.
 
 <DataTypeDefinition pattern="/\d+\.\d+/" example="1.1248" />
 
-## isic_code
+## hs_code
 
-International Standard Industry Classification. This is mandatory for the
-customs form when shipping outside EU. Codes can be found on
-the [Douane](https://tarief.douane.nl/arctictariff-public-web/#!/taric/nomenclature/sbn?d=I&cc=&l=nl&ql=nl&ea=false)
+Harmonized System code. HS codes classify goods for customs and consist of 6 to 10 digits. 
+Countries add their own endings for use in export and import customs clearance.
+This is mandatory for the customs form when shipping outside EU. Codes can be found on
+the [Douane](https://tarief.douane.nl/ite-tariff-public/#/taric/nomenclature/sbn?sd=2026-01-21&d=I&l=nl&ql=nl)
 website.
+Per carrier the supported lengths vary:
+DPD:   8
+DHL:   8 or 10
+Bpost: 6 or 8
+Other: 6, 8, or 10
 
-<DataTypeDefinition pattern="/\d{1,4}/" example="9609 (Pencils)" />
+To the US, 10 character HS codes are required.
+
+<DataTypeDefinition pattern="/\d{6,10}/" example="960910 (Pencils, including propelling pencils)" />
 
 ## label_position
 

--- a/src/api-reference/04.data-types.md
+++ b/src/api-reference/04.data-types.md
@@ -25,8 +25,14 @@ Platform name
 
 Carrier id
 
+**Note:** Some carrier IDs are deprecated and should not be used for new shipments:
+- Carrier 5 (Instabox) - DEPRECATED
+- Carrier 6 (DHLCheapCargo) - DEPRECATED  
+- Carrier 7 (BOL) - DEPRECATED
+- Carrier 8 (UPS) - DEPRECATED (replaced by carriers 12 and 13)
+
 <DataTypeDefinition 
-  values="1,2,3,4,5,9,10,11,12,13,14,15,16" 
+  values="1,2,3,4,9,10,11,12,13,14,15,16,17,18" 
   example="
     1 (PostNL),
     2 (bpost. Only available on sendmyparcel.be),
@@ -39,7 +45,9 @@ Carrier id
     13 (UPS Express Saver. Only available on MyParcel.nl),
     14 (GLS. Only available on MyParcel.nl),
     15 (BRT),
-    16 (Trunkrs)
+    16 (Trunkrs),
+    17 (InPost),
+    18 (PosteItaliane)
 " />
 
 ## coordinates

--- a/src/api-reference/04.data-types.md
+++ b/src/api-reference/04.data-types.md
@@ -159,7 +159,9 @@ The different shipments you can create. For SendMyParcel
 only <DataType type="package-type" id="1" /> (package) and <DataType type="package-type" id="2" /> (mailbox package) are allowed.
 For MyParcel it is possible to create international mailbox packages if you have a PostNL contract that allows you to use that product. If you don't have such a contract, you can't create international mailbox package shipments.
 
-<DataTypeDefinition values="1,2,3,4,5,6" example="1. package,2. mailbox package,3. letter,4. digital stamp,5. pallet,6. small package" />
+Note: <DataType type="package-type" id="7" /> (envelope) is currently only used by <DataType type="carrier" name="DHL for You" /> shipments.
+
+<DataTypeDefinition values="1,2,3,4,5,6,7" example="1. package,2. mailbox package,3. letter,4. digital stamp,5. pallet,6. small package,7. envelope" />
 
 ## paper_size
 

--- a/src/api-reference/04.data-types.md
+++ b/src/api-reference/04.data-types.md
@@ -16,11 +16,6 @@ Array of elements. Can contain all other data types.
 Boolean value
 <DataTypeDefinition values="0,1" />
 
-## platform
-
-Platform name
-<DataTypeDefinition values="myparcel,belgie" />
-
 ## carrier
 
 Carrier id
@@ -96,12 +91,6 @@ case of a B2B shipment.
 
 <DataTypeDefinition pattern="/[A-Z]{2}\d{9,12}/" example="NL012345678" />
 
-## integer
-
-Numeric value.
-
-<DataTypeDefinition pattern="/\d+/" example="20,5" />
-
 ## float
 
 Numeric value with decimal fractions.
@@ -124,6 +113,12 @@ Other: 6, 8, or 10
 To the US, 10 character HS codes are required.
 
 <DataTypeDefinition pattern="/\d{6,10}/" example="960910 (Pencils, including propelling pencils)" />
+
+## integer
+
+Numeric value.
+
+<DataTypeDefinition pattern="/\d+/" example="20,5" />
 
 ## label_position
 
@@ -176,6 +171,11 @@ Note: <DataType type="package-type" id="7" /> (envelope) is currently only used 
 The size of a paper as specified in ISO216.
 
 <DataTypeDefinition values="a4,a6" />
+
+## platform
+
+Platform name
+<DataTypeDefinition values="myparcel,belgie" />
 
 ## price
 

--- a/src/api-reference/06.shipments.md
+++ b/src/api-reference/06.shipments.md
@@ -3464,7 +3464,7 @@ HTTP/1.1 204 No Content
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/api-reference/06.shipments.md
+++ b/src/api-reference/06.shipments.md
@@ -89,13 +89,13 @@ for BE. The address of the package determines the delivery types available. You
 need to use the DeliveryOptions interface to fetch the delivery types for a
 specific address. It is also possible to specify a date on which the package has
 to be delivered with the ShipmentOptions.delivery_date field. With delivery
-types 1, 3, and 8 ShipmentOptions.delivery_date is required.
+types 1 and 3 ShipmentOptions.delivery_date is required.
 
 #### 1. Morning
 
-This option is only available for certain NL addresses. It allows a
+This option is only available for certain NL addresses and for <DataType type="carrier" name="BRT" />. It allows a
 Customer/Consumer to have their package delivered early in the morning on the
-delivery date specified except on Saturday and Sunday.
+delivery date specified (except on Saturday and Sunday).
 
 #### 2. Standard
 
@@ -128,7 +128,7 @@ Express delivery option for faster delivery service.
 
 #### 8. Early Morning
 
-Early morning delivery option. The package will be delivered in the early morning hours (before standard morning delivery).
+Early morning delivery option. The package will be delivered in the early morning hours (earlier than the regular morning delivery).
 
 ### 6.A.3 Options
 
@@ -240,7 +240,7 @@ Hide the sender information on the label. Only available for <DataType type="car
 
 #### same_day_delivery
 
-Same day delivery service. The package will be delivered on the same day it is shipped. Only available for <DataType type="carrier" name="DHL for You" /> for domestic NL shipments. Also known as "DHL Today" with delivery between 16:30 and 21:30.
+Same day delivery service. The package will be delivered on the same day it is shipped. Only available for <DataType type="carrier" name="DHL for You" /> for domestic NL shipments, and for <DataType type="carrier" name="Trunkrs" />. Also known as "DHL Today" with delivery between 16:30 and 21:30.
 
 #### printerless_return
 

--- a/src/api-reference/06.shipments.md
+++ b/src/api-reference/06.shipments.md
@@ -137,29 +137,37 @@ signature on receipt, XL format etc. These options are specified in
 the <ApiLink to="7_C">ShipmentOptions</ApiLink>
 object.
 
-#### only_recipient
+#### age_check
 
-Deliver the package only at address of the intended recipient.
+Only available on <DataType type="platform" id="1" />.
+The Customer/Consumer must sign for the
+package and only receive it when he is at least 18 years.
 
-#### signature
+#### collect
 
-Recipient must sign for the package. This option is required for Pickup and
-Pickup express delivery types.
+Collect service option for scheduled package collection. Only available for <DataType type="carrier" name="trunkrs" />.
 
-For <DataType type="carrier" name="gls" /> signature can be disabled (in combination with insurance) for sending a package
-inside The Netherlands (excluding Wadden Islands).
+#### drop_off_at_postal_point
 
-#### return
+Drop off the package at a postal point instead of regular collection.
 
-Return the package to the sender when the recipient is not home.
+#### extra_assurance
 
-#### large_format
+Additional assurance option for extra peace of mind. Only available for <DataType type="carrier" name="DHL for You" />.
 
-This option must be specified for PostNL shipments if the dimensions of the package are between 100 x
-70 x 58 and 175 x 78 x 58 cm or heavier than 23 kg. If the scanned dimensions from the carrier
-indicate that this package is large format, and it has not been specified then
-it will be added to the shipment in the billing process. This option is also
-available for EU shipments.
+#### fresh_food
+
+The shipment contains fresh food and requires special handling such as cooled transport and/or same-day delivery. Only
+available for <DataType type="carrier" name="trunkrs" />
+
+#### frozen
+
+The shipment contains frozen items and requires special handling such as cooled transport, same-day delivery and/or a
+maximum amount of time outside the freezer. Only available for <DataType type="carrier" name="trunkrs"/>
+
+#### hide_sender
+
+Hide the sender information on the label. Only available for <DataType type="carrier" name="DHL for You" /> and <DataType type="carrier" name="DHL Europlus" /> for shipments to Netherlands and Belgium.
 
 #### insurance
 
@@ -187,17 +195,42 @@ For <DataType type="carrier" name="gls"/> the insurance amount is €500,00. No 
 for insurance. Insurance can be disabled (together with the signature) for sending a package
 inside The Netherlands (excluding Wadden Islands).
 
-#### age_check
+#### large_format
 
-Only available on <DataType type="platform" id="1" />.
-The Customer/Consumer must sign for the
-package and only receive it when he is at least 18 years.
+This option must be specified for PostNL shipments if the dimensions of the package are between 100 x
+70 x 58 and 175 x 78 x 58 cm or heavier than 23 kg. If the scanned dimensions from the carrier
+indicate that this package is large format, and it has not been specified then
+it will be added to the shipment in the billing process. This option is also
+available for EU shipments.
+
+#### only_recipient
+
+Deliver the package only at address of the intended recipient.
 
 #### priority_delivery
 
 Only available on <DataType type="platform" id="1" /> with <DataType type="carrier" name="postnl" /> and <DataType type="package-type" id="2" />.\
 If set, the shipment will be delivered as a priority mailbox package (24 hours).\
 If unset, the shipment will be delivered as a standard mailbox package (48 hours).
+
+#### printerless_return
+
+Printerless return service allows returns without a printed label. Only available for return shipments with <DataType type="carrier" name="postnl" /> (domestic NL) and <DataType type="carrier" name="DHL for You" /> (NL and BE). Cannot be combined with most other shipment options and requires specific account settings.
+
+#### receipt_code
+
+Also known as 'Ontvangstcode'. The recipient receives a code via email or SMS that must be confirmed upon delivery.
+Only available for <DataType type="carrier" name="postnl" /> and <DataType type="carrier" name="trunkrs" />.
+
+For <DataType type="carrier" name="postnl" /> this requires insurance and recipient email address.
+
+#### return
+
+Return the package to the sender when the recipient is not home.
+
+#### same_day_delivery
+
+Same day delivery service. The package will be delivered on the same day it is shipped. Only available for <DataType type="carrier" name="DHL for You" /> for domestic NL shipments, and for <DataType type="carrier" name="Trunkrs" />. Also known as "DHL Today" with delivery between 16:30 and 21:30.
 
 #### saturday_delivery
 
@@ -206,6 +239,14 @@ for delivery on saturdays.
 Available on <DataType type="platform" id="3" /> and carrier bpost. An additional fee is paid
 for delivery on saturdays.
 Available on <DataType type="platform" id="1" /> and carrier <DataType type="carrier" name="gls"/>. An additional fee is paid for delivery on saturdays.
+
+#### signature
+
+Recipient must sign for the package. This option is required for Pickup and
+Pickup express delivery types.
+
+For <DataType type="carrier" name="gls" /> signature can be disabled (in combination with insurance) for sending a package
+inside The Netherlands (excluding Wadden Islands).
 
 #### tracked
 
@@ -216,47 +257,6 @@ There is one exception: a small package shipment to Belgium.
 If you have a PostNL contract that allows you to use international small packages under agreed conditions with PostNL, you can use the tracked option.
 If you don't have such a contract, the small package shipment to Belgium has the same options as a <DataType type="package-type" id="1" />
 shipment to Belgium and the tracked option is not available.
-
-#### receipt_code
-
-Also known as 'Ontvangstcode'. The recipient receives a code via email or SMS that must be confirmed upon delivery.
-Only available for <DataType type="carrier" name="postnl" /> and <DataType type="carrier" name="trunkrs" />.
-
-For <DataType type="carrier" name="postnl" /> this requires insurance and recipient email address.
-
-#### fresh_food
-
-The shipment contains fresh food and requires special handling such as cooled transport and/or same-day delivery. Only
-available for <DataType type="carrier" name="trunkrs" />
-
-#### frozen
-
-The shipment contains frozen items and requires special handling such as cooled transport, same-day delivery and/or a
-maximum amount of time outside the freezer. Only available for <DataType type="carrier" name="trunkrs"/>
-
-#### hide_sender
-
-Hide the sender information on the label. Only available for <DataType type="carrier" name="DHL for You" /> and <DataType type="carrier" name="DHL Europlus" /> for shipments to Netherlands and Belgium.
-
-#### same_day_delivery
-
-Same day delivery service. The package will be delivered on the same day it is shipped. Only available for <DataType type="carrier" name="DHL for You" /> for domestic NL shipments, and for <DataType type="carrier" name="Trunkrs" />. Also known as "DHL Today" with delivery between 16:30 and 21:30.
-
-#### printerless_return
-
-Printerless return service allows returns without a printed label. Only available for return shipments with <DataType type="carrier" name="postnl" /> (domestic NL) and <DataType type="carrier" name="DHL for You" /> (NL and BE). Cannot be combined with most other shipment options and requires specific account settings.
-
-#### collect
-
-Collect service option for scheduled package collection. Only available for <DataType type="carrier" name="trunkrs" />.
-
-#### drop_off_at_postal_point
-
-Drop off the package at a postal point instead of regular collection.
-
-#### extra_assurance
-
-Additional assurance option for extra peace of mind. Only available for <DataType type="carrier" name="DHL for You" />.
 
 ### 6.A.4 Examples
 

--- a/src/api-reference/06.shipments.md
+++ b/src/api-reference/06.shipments.md
@@ -31,8 +31,7 @@ used when creating shipments.
 
 #### 2. Mailbox package
 
-This package type is available on <DataType type="platform" id="1" />
-and <DataType type="platform" id="2" /> for PostNL NL shipments that fit into a
+This package type is available on <DataType type="platform" id="1" /> for PostNL NL shipments that fit into a
 mailbox. It supports the `priority_delivery` shipment option. This option is only available for <DataType type="carrier" name="postnl" />.\
 On <DataType type="platform" id="3" /> this package type is available for bpost BE
 shipments that fit into a mailbox. It does not support additional options.\
@@ -82,15 +81,15 @@ For international shipments, two shipments options are available: tracked and in
 
 ### 6.A.2 Delivery types
 
-There are five different delivery types and these specify how the package is
+There are eight different delivery types and these specify how the package is
 delivered. The value is sent with the ShipmentOptions.delivery_type field.
 Currently, delivery types are only available for NL and BE shipments
-with <DataType type="package-type" id="1" />. Delivery types 1-5 for NL and 1,4
+with <DataType type="package-type" id="1" />. Delivery types 1-8 for NL and 1,4
 for BE. The address of the package determines the delivery types available. You
 need to use the DeliveryOptions interface to fetch the delivery types for a
 specific address. It is also possible to specify a date on which the package has
 to be delivered with the ShipmentOptions.delivery_date field. With delivery
-types 1 & 3 ShipmentOptions.delivery_date is required.
+types 1, 3, and 8 ShipmentOptions.delivery_date is required.
 
 #### 1. Morning
 
@@ -105,7 +104,7 @@ This is the standard delivery type.
 #### 3. Evening
 
 This option is only available on <DataType type="platform" id="1" />
-and <DataType type="platform" id="2" /> for certain NL addresses. It allows a
+for certain NL addresses. It allows a
 Customer/Consumer to have their package delivered in the evening on the
 specified delivery date.
 
@@ -116,8 +115,20 @@ Consumer/Customer.
 
 #### 5. Pickup express
 
-The same as pickup but the package is available for pickup before 8:30AM on the
+The same as pickup, but the package is available for pickup before 8:30AM on the
 delivery date specified at the drop-off location. Only available on MyParcel.nl.
+
+#### 6. Same Day
+
+Same day delivery option. The package will be delivered on the same day it is shipped.
+
+#### 7. Express
+
+Express delivery option for faster delivery service.
+
+#### 8. Early Morning
+
+Early morning delivery option. The package will be delivered in the early morning hours (before standard morning delivery).
 
 ### 6.A.3 Options
 
@@ -178,8 +189,8 @@ inside The Netherlands (excluding Wadden Islands).
 
 #### age_check
 
-Only available on <DataType type="platform" id="1" />
-and <DataType type="platform" id="2" />. The Customer/Consumer must sign for the
+Only available on <DataType type="platform" id="1" />.
+The Customer/Consumer must sign for the
 package and only receive it when he is at least 18 years.
 
 #### priority_delivery
@@ -222,6 +233,30 @@ available for <DataType type="carrier" name="trunkrs" />
 
 The shipment contains frozen items and requires special handling such as cooled transport, same-day delivery and/or a
 maximum amount of time outside the freezer. Only available for <DataType type="carrier" name="trunkrs"/>
+
+#### hide_sender
+
+Hide the sender information on the label. Only available for <DataType type="carrier" name="DHL for You" /> and <DataType type="carrier" name="DHL Europlus" /> for shipments to Netherlands and Belgium.
+
+#### same_day_delivery
+
+Same day delivery service. The package will be delivered on the same day it is shipped. Only available for <DataType type="carrier" name="DHL for You" /> for domestic NL shipments. Also known as "DHL Today" with delivery between 16:30 and 21:30.
+
+#### printerless_return
+
+Printerless return service allows returns without a printed label. Only available for return shipments with <DataType type="carrier" name="postnl" /> (domestic NL) and <DataType type="carrier" name="DHL for You" /> (NL and BE). Cannot be combined with most other shipment options and requires specific account settings.
+
+#### collect
+
+Collect service option for scheduled package collection. Only available for <DataType type="carrier" name="trunkrs" />.
+
+#### drop_off_at_postal_point
+
+Drop off the package at a postal point instead of regular collection.
+
+#### extra_assurance
+
+Additional assurance option for extra peace of mind. Only available for <DataType type="carrier" name="DHL for You" />.
 
 ### 6.A.4 Examples
 

--- a/src/api-reference/07.shipment-related-object-definitions.md
+++ b/src/api-reference/07.shipment-related-object-definitions.md
@@ -1048,9 +1048,9 @@ Required: Yes.
 Item value
 
 **classification**  
-Data type: [isic_code]  
+Data type: [hs_code]  
 Required: Yes.  
-The International Standard Industry Classification code for this item.
+The Harmonized System (HS) code for this item. HS codes classify goods for customs and consist of 6 to 10 digits.
 
 **country**  
 Data type: [country_code]  
@@ -1939,7 +1939,7 @@ nullable: true
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/api-reference/07.shipment-related-object-definitions.md
+++ b/src/api-reference/07.shipment-related-object-definitions.md
@@ -746,7 +746,7 @@ Deliver the package to the recipient only.
 **package_type**   
 Data type: [package_type]   
 Required: yes   
-The package type. For international shipment only <DataType type="package-type" id="1" /> (package) is allowed.
+The package type. For international shipments, the available package types depend on the carrier and your contract. <DataType type="package-type" id="1" /> (package) is generally supported. International <DataType type="package-type" id="2" /> (mailbox package) is available for PostNL with certain contracts.
 
 **priority_delivery**   
 Data type: [boolean]   

--- a/src/api-reference/08.delivery-options.md
+++ b/src/api-reference/08.delivery-options.md
@@ -823,7 +823,7 @@ Accept: application/json;charset=utf-8;version=2.0
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/api-reference/09.delivery-options-object-definitions.md
+++ b/src/api-reference/09.delivery-options-object-definitions.md
@@ -310,7 +310,7 @@ Required: n/a.
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/api-reference/10.webhooks.md
+++ b/src/api-reference/10.webhooks.md
@@ -186,7 +186,7 @@ Authorization: bearer BASE64_ENCODED_API_KEY
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/api-reference/11.webhook-object-definitions.md
+++ b/src/api-reference/11.webhook-object-definitions.md
@@ -250,7 +250,7 @@ Required: n/a.
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/api-reference/12.drop-off-points.md
+++ b/src/api-reference/12.drop-off-points.md
@@ -130,7 +130,7 @@ accept: application/json;charset=utf-8
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/api-reference/13.orders.md
+++ b/src/api-reference/13.orders.md
@@ -747,7 +747,7 @@ Content-Type: application/pdf
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/api-reference/14.order-object-definitions.md
+++ b/src/api-reference/14.order-object-definitions.md
@@ -671,7 +671,7 @@ Reference to the order line in the order shipment.
 [eori_number]: /api-reference/04.data-types.html#eori-number
 [float]: /api-reference/04.data-types.html#float
 [integer]: /api-reference/04.data-types.html#integer
-[isic_code]: /api-reference/04.data-types.html#isic-code
+[hs_code]: /api-reference/04.data-types.html#hs-code
 [label_position]: /api-reference/04.data-types.html#label-position
 [main]: /api-reference/04.data-types.html#main
 [month_digit]: /api-reference/04.data-types.html#month-digit

--- a/src/documentation/50.php-sdk.md
+++ b/src/documentation/50.php-sdk.md
@@ -1025,8 +1025,8 @@ is mandatory for non-EU shipments.
 ```php
   ->setAmount(3) // Amount of items in the package
 
-  // ISIC/IDEP code (https://www.cbs.nl/nl-nl/deelnemers-enquetes/deelnemers-enquetes/bedrijven/onderzoek/lopend/internationale-handel-in-goederen/idep-codelijsten)
-  ->setClassification(0111) // Example: 0111 = "Growing of cereals (except rice), leguminous crops and oil seeds"
+  // HS code (Harmonized System code): https://tarief.douane.nl/ite-tariff-public/#/taric/nomenclature/sbn?sd=2026-01-21&d=I&l=nl&ql=nl
+  ->setClassification('010110') // Example: 010110 = "Horses - pure-bred breeding animals"
   ->setCountry('NL') // Country of origin
   ->setDescription('Cereal grains')
   ->setItemValue(40000) // Price of item in cents


### PR DESCRIPTION
Een klant wees ons erop dat wij ISIC codes in onze documentatie noemen, terwijl wij eigenlijk HS codes gebruiken, dus pas ik dat hier aan.

Heb ook gelijk even de shipment options, package types, delivery types, en carriers nagelopen en aangevuld waar nodig.

Ook referenties naar platform 2 (Flespakket) verwijderd.